### PR TITLE
Added possibility to specify database config on command line

### DIFF
--- a/lib/capistrano/tasks/wp.cap
+++ b/lib/capistrano/tasks/wp.cap
@@ -128,6 +128,11 @@ namespace :wp do
     task :both do
       set :setup_all, true
 
+      # Setup both only works with a database.yml file
+      if !File.exists?('config/database.yml') || (ENV['db_host'] || ENV['db_name'] || ENV['db_user'] || ENV['db_password'])
+        raise "Setup both only works with a database.yml file."
+      end
+
       # Generate a random password
       o = [('a'..'z'), ('A'..'Z')].map { |i| i.to_a }.flatten
       password = (0...18).map { o[rand(o.length)] }.join

--- a/lib/capistrano/tasks/wp.cap
+++ b/lib/capistrano/tasks/wp.cap
@@ -16,7 +16,9 @@ namespace :wp do
         # Get details for WordPress config file
         secret_keys = capture("curl -s -k https://api.wordpress.org/secret-key/1.1/salt")
         wp_siteurl = fetch(:stage_url)
-        database = YAML::load_file('config/database.yml')[fetch(:stage).to_s]
+
+        # Load database configuration
+        database = load_database_configuration(fetch(:stage).to_s)
 
         # Create config file in remote environment
         db_config = ERB.new(File.read('config/templates/wp-config.php.erb')).result(binding)
@@ -96,8 +98,10 @@ namespace :wp do
         user = fetch(:wp_user)
         wp_siteurl = fetch(:wp_localurl)
 
+        # Load database configuration
+        database = load_database_configuration('local')
+
         # Create wp-config.php
-        database = YAML::load_file('config/database.yml')['local']
         secret_keys = capture("curl -s -k https://api.wordpress.org/secret-key/1.1/salt")
         db_config = ERB.new(File.read('config/templates/wp-config.php.erb')).result(binding)
         File.open("wp-config.php", 'w') {|f| f.write(db_config) }
@@ -150,4 +154,36 @@ namespace :wp do
     end
   end
 
+end
+
+# Loads and returns the database configuration as a hash.
+# 
+# If `db_host`, `db_name`, `db_user` and `db_password` are passed on the command line,
+# those values are used for the database configuration. Otherwise, the configuration
+# is loaded from a `config/database.yml` file.
+# 
+# If neither of those are present, an exception is raised.
+def load_database_configuration(environment)
+  if ENV['db_host'] && ENV['db_name'] && ENV['db_user'] && ENV['db_password']
+    database = {
+      'host' => ENV['db_host'],
+      'database' => ENV['db_name'],
+      'username' => ENV['db_user'],
+      'password' => ENV['db_password']
+    }
+  elsif File.exists?('config/database.yml')
+    database = YAML::load_file('config/database.yml')[environment]
+  else
+    puts <<-MSG
+    \e[31m
+      Incomplete database configuration specified and no config/database.yml
+      file found. Specify db_host, db_name, db_user and db_password options
+      or create a config/database.yml file. See the readme for more info.
+    \e[0m
+    MSG
+
+    raise "Incorrect database configuration"
+  end
+
+  return database
 end

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,16 @@ This is where you define your SSH access to the remote server, and the full path
 
 `server` can be an IP address or domain; prefixing with `http://` is not needed either way. 
 
-You also need to rename `database.example.yml` to `database.yml` and fill it with the database details for each environment, including your local one. This file should stay ignored in git.
+
+#### Database configuration
+To set up WordPress on your a remote or local server, wp-deploy needs to know the database configuration for that specific environment. You can either specify this as options on the commandline, or use a `database.yml` file.
+To use the command line options, specify the following options when calling a setup task:
+
+```sh
+$ bundle exec cap production wp:setup:remote db_host=<localhost> db_name=<database> db_user=<username> db_password=<password>
+```
+
+To use a `database.yml` file, you need to rename `database.example.yml` to `database.yml` and fill it with the database details for each environment, including your local one. This file should stay ignored in git.
 
 #### .wpignore
 
@@ -109,7 +118,7 @@ wp-deploy makes use of [capistrano-slackify](https://github.com/onthebeach/capis
 
 #### Setting up environments
 
-To set up WordPress on your remote production server, run the following command:
+To set up WordPress on your remote production server, run the following command. Include the database configuration if you do not use a `database.yml file` (See Database configuration).
 
 ```sh
 $ bundle exec cap production wp:setup:remote
@@ -117,7 +126,7 @@ $ bundle exec cap production wp:setup:remote
 
 This will install WordPress using the details in your configuration files, and make your first deployment on your production server. wp-deploy will generate a random password and give it to you at the end of the task, so be sure to write it down and change it to something more momorable when you log in.
 
-You can also automate the set-up of your local environment too, using `wp:setup:local`, or you can save time and set up both your remote and local environments with `wp:setup:both`.
+You can also automate the set-up of your local environment too, using `wp:setup:local`, or you can save time and set up both your remote and local environments with `wp:setup:both`. This only works when using a `database.yml` file.
 
 #### Deploying
 


### PR DESCRIPTION
Pull request for issue: https://github.com/Mixd/wp-deploy/issues/30

I opted for command line arguments instead of prompts so that even without a `database.yml` file, the command can still be run without supervision.

When `db_host`, `db_name`, `db_user` and `db_password` are specified, they are used for the database configuration. Otherwise, the database.yml file is used. For the wp:setup:both task, only the database.yml file is supported.