### PR TITLE
Added port to content sync task

### DIFF
--- a/lib/capistrano/tasks/content.cap
+++ b/lib/capistrano/tasks/content.cap
@@ -4,7 +4,7 @@ namespace :uploads do
   task :push do
     run_locally do
         roles(:all).each do |role|
-                execute :rsync, "-avzO content/uploads/ #{role.user}@#{role.hostname}:#{shared_path}/content/uploads"
+                execute :rsync, "-avzO" + (role.port ? " -e 'ssh -p #{role.port}'" : "") + " content/uploads/ #{role.user}@#{role.hostname}:#{shared_path}/content/uploads"
           end
       end
   end
@@ -13,7 +13,7 @@ namespace :uploads do
   task :pull do
     run_locally do
         roles(:all).each do |role|
-                execute :rsync, "-avzO #{role.user}@#{role.hostname}:#{shared_path}/content/uploads/ content/uploads"
+                execute :rsync, "-avzO" + (role.port ? " -e 'ssh -p #{role.port}'" : "") + " #{role.user}@#{role.hostname}:#{shared_path}/content/uploads/ content/uploads"
           end
       end
   end


### PR DESCRIPTION
cap [env] uploads:push / pull fails if the port is not 22. 
This adds the port into the rsync command if it's set for this role. 

Thanks!