### PR TITLE
Compatibility for Submodule Strategy release checkout command with older git versions

### DIFF
--- a/lib/capistrano/submodule_strategy.rb
+++ b/lib/capistrano/submodule_strategy.rb
@@ -26,8 +26,9 @@ module SubmoduleStrategy
   # and copy everything to the release path
   def release
     release_branch = fetch(:release_branch, File.basename(release_path))
-    git :checkout, '-B', release_branch, 
+    git :branch, '-f', release_branch,
       fetch(:remote_branch, "origin/#{fetch(:branch)}")
+    git :checkout
     git :submodule, :update, '--init'
     context.execute "rsync -ar --filter=':- .wpignore' --exclude=.git\* #{repo_path}/ #{release_path}"
   end


### PR DESCRIPTION
Applied a small change to the submodule strategy checkout commands.
It's just the replacement of the shortcut command with the full sequence, no change to functionality.

git checkout -B " is a shorter way to say "git branch -f" followed by "git checkout"
([git 1.7.3 Release Notes](https://git.kernel.org/cgit/git/git.git/tree/Documentation/RelNotes/1.7.3.txt))

However, this enables compatibility with environments running older git versions before the shortcut command was introduced.  (Tested with git 1.7.1 on CentOS 6.6)

(see also: https://github.com/Mixd/wp-deploy/issues/41 ) 

Thanks!