### PR TITLE
Fix core update to return latest tag

### DIFF
--- a/lib/capistrano/tasks/wp.cap
+++ b/lib/capistrano/tasks/wp.cap
@@ -142,7 +142,7 @@ namespace :wp do
       system('
       cd wordpress
       git fetch --tags
-      latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
+      latestTag=$(git tag --sort=-v:refname | sed -n 1p )
       git checkout $latestTag
       ')
       invoke 'cache:repo:purge'

--- a/lib/capistrano/tasks/wp.cap
+++ b/lib/capistrano/tasks/wp.cap
@@ -142,7 +142,7 @@ namespace :wp do
       system('
       cd wordpress
       git fetch --tags
-      latestTag=$(git tag --sort=-v:refname | sed -n 1p )
+      latestTag=$(git tag -l | sort -n -r -t. -k1,1 -k2,2 -k3,3 -k4,4 | sed -n 1p)
       git checkout $latestTag
       ')
       invoke 'cache:repo:purge'


### PR DESCRIPTION
This sorts the tag list by version order (in reverse, so the newest comes
first) then pipes to sed to select the first item. Fixes #75 

I've tested locally, works on OSX 10.10