### PR TITLE
Ensure the backup filename uses padding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ wp-config.php
 _assets
 node_modules
 ai-cache/*
+
+.bundle/
+.direnv/
+.envrc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    capistrano (3.4.0)
+    airbrussh (1.0.2)
+      sshkit (>= 1.6.1, != 1.7.0)
+    capistrano (3.5.0)
+      airbrussh (>= 1.0.0)
+      capistrano-harrow
       i18n
       rake (>= 10.0.0)
-      sshkit (~> 1.3)
+      sshkit (>= 1.9.0)
+    capistrano-harrow (0.5.1)
     capistrano-slackify (2.2.0)
       capistrano (>= 3.1.0)
       multi_json
-    colorize (0.7.5)
     i18n (0.7.0)
-    multi_json (1.11.0)
+    multi_json (1.12.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
-    rake (10.4.2)
-    sshkit (1.7.1)
-      colorize (>= 0.7.0)
+    net-ssh (3.1.1)
+    rake (11.2.2)
+    sshkit (1.11.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
 
@@ -26,3 +29,6 @@ PLATFORMS
 DEPENDENCIES
   capistrano (~> 3.4)
   capistrano-slackify (~> 2.2.0)
+
+BUNDLED WITH
+   1.12.2

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,8 @@
-# wp-deploy, A framework for deploying WordPress sites using Capistrano 3
+# wp-deploy
+
+A framework for deploying WordPress sites using Capistrano 3
+
+---
 
 Copyright (C) 2015 Mixd
 


### PR DESCRIPTION
Currently, the backup files will have names of different lengths as the timestamps are not 0-padded. 
With this fix they all have the same length.
