### PR TITLE
Follow the ruby style guide

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,8 @@
-# wp-deploy, A framework for deploying WordPress sites using Capistrano 3
+# wp-deploy
+
+A framework for deploying WordPress sites using Capistrano 3
+
+---
 
 Copyright (C) 2015 Mixd
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,17 +8,17 @@ require './config/slack'
 # Setup WordPress
 ############################################
 
-set :wp_user, "yourname" # The admin username
-set :wp_email, "yourname@example.com" # The admin email address
-set :wp_sitename, "WP Deploy" # The site title
-set :wp_localurl, "http://wpdeploy" # Your local environment URL
+set :wp_user, 'yourname' # The admin username
+set :wp_email, 'yourname@example.com' # The admin email address
+set :wp_sitename, 'WP Deploy' # The site title
+set :wp_localurl, 'http://wpdeploy' # Your local environment URL
 
 ############################################
 # Setup project
 ############################################
 
-set :application, "wp-deploy"
-set :repo_url, "git@github.com:Mixd/wp-deploy.git"
+set :application, 'wp-deploy'
+set :repo_url, 'git@github.com:Mixd/wp-deploy.git'
 set :scm, :git
 
 set :git_strategy, SubmoduleStrategy
@@ -30,9 +30,7 @@ set :git_strategy, SubmoduleStrategy
 set :log_level, :info
 set :use_sudo, false
 
-set :ssh_options, {
-  forward_agent: true
-}
+set :ssh_options,   forward_agent: true
 
 set :keep_releases, 5
 
@@ -40,12 +38,11 @@ set :keep_releases, 5
 # Linked files and directories (symlinks)
 ############################################
 
-set :linked_files, %w{wp-config.php .htaccess}
-set :linked_dirs, %w{content/uploads}
+set :linked_files, %w(wp-config.php .htaccess)
+set :linked_dirs, %w(content/uploads)
 
 namespace :deploy do
-
-  desc "create WordPress files for symlinking"
+  desc 'create WordPress files for symlinking'
   task :create_wp_files do
     on roles(:app) do
       execute :touch, "#{shared_path}/wp-config.php"
@@ -55,20 +52,19 @@ namespace :deploy do
 
   after 'check:make_linked_dirs', :create_wp_files
 
-  desc "Creates robots.txt for non-production envs"
+  desc 'Creates robots.txt for non-production envs'
   task :create_robots do
-  	on roles(:app) do
-  		if fetch(:stage) != :production then
+    on roles(:app) do
+      if fetch(:stage) != :production
 
-		    io = StringIO.new('User-agent: *
+        io = StringIO.new('User-agent: *
 Disallow: /')
-		    upload! io, File.join(release_path, "robots.txt")
+        upload! io, File.join(release_path, 'robots.txt')
         execute :chmod, "644 #{release_path}/robots.txt"
       end
-  	end
+    end
   end
 
   after :finished, :create_robots
-  after :finishing, "deploy:cleanup"
-
+  after :finishing, 'deploy:cleanup'
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -3,27 +3,27 @@
 ############################################
 
 set :stage, :production
-set :stage_url, "http://www.example.com"
-server "XXX.XXX.XX.XXX", user: "SSHUSER", roles: %w{web app db}
-set :deploy_to, "/deploy/to/path"
+set :stage_url, 'http://www.example.com'
+server 'XXX.XXX.XX.XXX', user: 'SSHUSER', roles: %w(web app db)
+set :deploy_to, '/deploy/to/path'
 
 ############################################
 # Setup Git
 ############################################
 
-set :branch, "master"
+set :branch, 'master'
 
 ############################################
 # Extra Settings
 ############################################
 
-#specify extra ssh options:
+# specify extra ssh options:
 
-#set :ssh_options, {
+# set :ssh_options, {
 #    auth_methods: %w(password),
 #    password: 'password',
 #    user: 'username',
-#}
+# }
 
-#specify a specific temp dir if user is jailed to home
-#set :tmp_dir, "/path/to/custom/tmp"
+# specify a specific temp dir if user is jailed to home
+# set :tmp_dir, "/path/to/custom/tmp"

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -3,27 +3,27 @@
 ############################################
 
 set :stage, :staging
-set :stage_url, "http://www.example.com"
-server "XXX.XXX.XX.XXX", user: "SSHUSER", roles: %w{web app db}
-set :deploy_to, "/deploy/to/path"
+set :stage_url, 'http://www.example.com'
+server 'XXX.XXX.XX.XXX', user: 'SSHUSER', roles: %w(web app db)
+set :deploy_to, '/deploy/to/path'
 
 ############################################
 # Setup Git
 ############################################
 
-set :branch, "development"
+set :branch, 'development'
 
 ############################################
 # Extra Settings
 ############################################
 
-#specify extra ssh options:
+# specify extra ssh options:
 
-#set :ssh_options, {
+# set :ssh_options, {
 #    auth_methods: %w(password),
 #    password: 'password',
 #    user: 'username',
-#}
+# }
 
-#specify a specific temp dir if user is jailed to home
-#set :tmp_dir, "/path/to/custom/tmp"
+# specify a specific temp dir if user is jailed to home
+# set :tmp_dir, "/path/to/custom/tmp"

--- a/lib/capistrano/submodule_strategy.rb
+++ b/lib/capistrano/submodule_strategy.rb
@@ -1,33 +1,33 @@
 module SubmoduleStrategy
   # do all the things a normal capistrano git session would do
   include Capistrano::Git::DefaultStrategy
-  
+
   # check for a .git directory
   def test
     test! " [ -d #{repo_path}/.git ] "
   end
- 
+
   # same as in Capistrano::Git::DefaultStrategy
   def check
     test! :git, :'ls-remote', repo_url
   end
- 
+
   def clone
     git :clone, '-b', fetch(:branch), '--recursive', repo_url, repo_path
   end
- 
+
   # same as in Capistrano::Git::DefaultStrategy
   def update
     git :remote, :update
   end
- 
+
   # put the working tree in a release-branch,
   # make sure the submodules are up-to-date
   # and copy everything to the release path
   def release
     release_branch = fetch(:release_branch, File.basename(release_path))
-    git :checkout, '-B', release_branch, 
-      fetch(:remote_branch, "origin/#{fetch(:branch)}")
+    git :checkout, '-B', release_branch,
+        fetch(:remote_branch, "origin/#{fetch(:branch)}")
     git :submodule, :update, '--init'
     context.execute "rsync -ar --filter=':- .wpignore' --exclude=.git\* #{repo_path}/ #{release_path}"
   end

--- a/lib/capistrano/tasks/cache.cap
+++ b/lib/capistrano/tasks/cache.cap
@@ -1,15 +1,12 @@
 namespace :cache do
-
-	namespace :repo do
-		desc "Remove the cached repo from the server"
-		task :purge do
-			on roles(:web) do
-				repopath = fetch(:deploy_to)
-				execute :rm, "-rf #{repopath}/repo";
-				puts "Cached repo folder removed from server."
-			end
-
-		end
-	end
-
+  namespace :repo do
+    desc 'Remove the cached repo from the server'
+    task :purge do
+      on roles(:web) do
+        repopath = fetch(:deploy_to)
+        execute :rm, "-rf #{repopath}/repo"
+        puts 'Cached repo folder removed from server.'
+      end
+    end
+  end
 end

--- a/lib/capistrano/tasks/content.cap
+++ b/lib/capistrano/tasks/content.cap
@@ -1,21 +1,19 @@
 namespace :uploads do
-
-  desc "Push any changed or new files from local to remote"
+  desc 'Push any changed or new files from local to remote'
   task :push do
     run_locally do
-        roles(:all).each do |role|
-                execute :rsync, "-avzO" + (role.port ? " -e 'ssh -p #{role.port}'" : "") + " content/uploads/ #{role.user}@#{role.hostname}:#{shared_path}/content/uploads"
-          end
+      roles(:all).each do |role|
+        execute :rsync, '-avzO' + (role.port ? " -e 'ssh -p #{role.port}'" : '') + " content/uploads/ #{role.user}@#{role.hostname}:#{shared_path}/content/uploads"
       end
+    end
   end
 
-  desc "Pull any changed or new files from remote to local"
+  desc 'Pull any changed or new files from remote to local'
   task :pull do
     run_locally do
-        roles(:all).each do |role|
-                execute :rsync, "-avzO" + (role.port ? " -e 'ssh -p #{role.port}'" : "") + " #{role.user}@#{role.hostname}:#{shared_path}/content/uploads/ content/uploads"
-          end
+      roles(:all).each do |role|
+        execute :rsync, '-avzO' + (role.port ? " -e 'ssh -p #{role.port}'" : '') + " #{role.user}@#{role.hostname}:#{shared_path}/content/uploads/ content/uploads"
       end
+    end
   end
-
 end

--- a/lib/capistrano/tasks/db.cap
+++ b/lib/capistrano/tasks/db.cap
@@ -1,22 +1,18 @@
 namespace :db do
-
-	desc "Creates a sensible backup name for SQL files"
+  desc 'Creates a sensible backup name for SQL files'
   task :backup_name do
-  	on roles(:web) do
-
-	    execute :mkdir, "-p #{shared_path}/db_backups"
-	    backup_time = Time.now.strftime '%Y%m%d%H%M%S'
-	    set :backup_filename, backup_time
-	    set :backup_file, "#{shared_path}/db_backups/#{backup_time}.sql"
-
-	  end
+    on roles(:web) do
+      execute :mkdir, "-p #{shared_path}/db_backups"
+      backup_time = Time.now.strftime '%Y%m%d%H%M%S'
+      set :backup_filename, backup_time
+      set :backup_file, "#{shared_path}/db_backups/#{backup_time}.sql"
+    end
   end
 
-  desc "Confirms the database action before proceeeding"
+  desc 'Confirms the database action before proceeeding'
   task :confirm do
     on roles(:web) do
-
-      database = YAML::load_file('config/database.yml')[fetch(:stage).to_s]
+      database = YAML.load_file('config/database.yml')[fetch(:stage).to_s]
 
       set :confirmed, proc {
         puts <<-WARN
@@ -32,12 +28,12 @@ namespace :db do
   \033[0m
         WARN
         ask :answer, database['database']
-        if fetch(:answer) == database['database'] then
+        if fetch(:answer) == database['database']
           true
         else
           loopCount = 1
           loop do
-            loopCount = loopCount + 1
+            loopCount += 1
             puts "\033[31mYou typed the database name incorrectly. Please enter \033[0m\033[1m\033[34m#{database['database']}\033[0m\033[22m\033[0m\033[0m"
             ask :answer, database['database']
             break if loopCount == 3
@@ -45,9 +41,7 @@ namespace :db do
           end
         end
 
-        if fetch(:answer) == database['database'] then
-          true
-        end
+        true if fetch(:answer) == database['database']
       }.call
 
       unless fetch(:confirmed)
@@ -60,78 +54,63 @@ namespace :db do
         WARN
         exit
       end
-
     end
   end
 
-  desc "Takes a database dump from remote server"
+  desc 'Takes a database dump from remote server'
   task :backup do
-	 invoke 'db:backup_name'
-	  on roles(:db) do
+    invoke 'db:backup_name'
+    on roles(:db) do
+      within release_path do
+        execute :wp, "db export #{fetch(:backup_file)} --add-drop-table"
+      end
 
-	  	within release_path do
-		     execute :wp, "db export #{fetch(:backup_file)} --add-drop-table"
-		  end
+      system('mkdir -p db_backups')
+      download! "#{fetch(:backup_file)}", "db_backups/#{fetch(:backup_filename)}.sql"
 
-		 system('mkdir -p db_backups')
-		 download! "#{fetch(:backup_file)}", "db_backups/#{fetch(:backup_filename)}.sql"
+      within release_path do
+        execute :rm, "#{fetch(:backup_file)}"
+      end
+    end
+  end
 
-		 within release_path do
-		   execute :rm, "#{fetch(:backup_file)}"
-		 end
+  desc 'Imports the remote database into your local environment'
+  task :pull do
+    invoke 'db:backup'
 
-	  end
-	end
+    on roles(:db) do
+      run_locally do
+        execute :wp, "db import db_backups/#{fetch(:backup_filename)}.sql"
+        execute :wp, "search-replace #{fetch(:stage_url)} #{fetch(:wp_localurl)}"
+        execute :rm, "db_backups/#{fetch(:backup_filename)}.sql"
+        execute :rmdir, 'db_backups' if Dir['db_backups/*'].empty?
+      end
+    end
+  end
 
-	desc "Imports the remote database into your local environment"
-	task :pull do
-		invoke 'db:backup'
+  desc 'Imports the local database into your remote environment'
+  task :push do
+    invoke 'db:confirm'
 
-		on roles(:db) do
+    invoke 'db:backup_name'
+    on roles(:db) do
+      run_locally do
+        execute :mkdir, '-p db_backups'
+        execute :wp, "db export db_backups/#{fetch(:backup_filename)}.sql --add-drop-table"
+      end
 
-			run_locally do
-				execute :wp, "db import db_backups/#{fetch(:backup_filename)}.sql"
-				execute :wp, "search-replace #{fetch(:stage_url)} #{fetch(:wp_localurl)}"
-				execute :rm, "db_backups/#{fetch(:backup_filename)}.sql"
+      upload! "db_backups/#{fetch(:backup_filename)}.sql", "#{fetch(:backup_file)}"
 
-				if Dir['db_backups/*'].empty?
-					execute :rmdir, "db_backups"
-				end
-			end
+      within release_path do
+        execute :wp, "db import #{fetch(:backup_file)}"
+        execute :wp, "search-replace #{fetch(:wp_localurl)} #{fetch(:stage_url)}"
+        execute :rm, "#{fetch(:backup_file)}"
+      end
 
-		end
-
-	end
-
-	desc "Imports the local database into your remote environment"
-	task :push do
-
-      invoke 'db:confirm'
-
-		invoke 'db:backup_name'
-		on roles(:db) do
-
-			run_locally do
-				execute :mkdir, "-p db_backups"
-				execute :wp, "db export db_backups/#{fetch(:backup_filename)}.sql --add-drop-table"
-			end
-
-			upload! "db_backups/#{fetch(:backup_filename)}.sql", "#{fetch(:backup_file)}"
-
-			within release_path do
-				execute :wp, "db import #{fetch(:backup_file)}"
-				execute :wp, "search-replace #{fetch(:wp_localurl)} #{fetch(:stage_url)}"
-				execute :rm, "#{fetch(:backup_file)}"
-			end
-
-			run_locally do
-				execute :rm, "db_backups/#{fetch(:backup_filename)}.sql"
-				if Dir['db_backups/*'].empty?
-					execute :rmdir, "db_backups"
-				end
-			end
-
-		end
-	end
-
+      run_locally do
+        execute :rm, "db_backups/#{fetch(:backup_filename)}.sql"
+        execute :rmdir, 'db_backups' if Dir['db_backups/*'].empty?
+      end
+    end
+  end
 end

--- a/lib/capistrano/tasks/wp.cap
+++ b/lib/capistrano/tasks/wp.cap
@@ -1,5 +1,4 @@
 namespace :wp do
-
   task :set_permissions do
     on roles(:app) do
       execute :chmod, "666 #{shared_path}/.htaccess"
@@ -8,42 +7,38 @@ namespace :wp do
   end
 
   namespace :setup do
-
-    desc "Generates wp-config.php on remote server"
+    desc 'Generates wp-config.php on remote server'
     task :generate_remote_files do
       on roles(:web) do
-
         # Get details for WordPress config file
-        secret_keys = capture("curl -s -k https://api.wordpress.org/secret-key/1.1/salt")
+        secret_keys = capture('curl -s -k https://api.wordpress.org/secret-key/1.1/salt')
         wp_siteurl = fetch(:stage_url)
-        database = YAML::load_file('config/database.yml')[fetch(:stage).to_s]
+        database = YAML.load_file('config/database.yml')[fetch(:stage).to_s]
 
         # Create config file in remote environment
         db_config = ERB.new(File.read('config/templates/wp-config.php.erb')).result(binding)
         io = StringIO.new(db_config)
-        upload! io, File.join(shared_path, "wp-config.php")
+        upload! io, File.join(shared_path, 'wp-config.php')
 
         # Create .htaccess in remote environment
         accessfile = ERB.new(File.read('config/templates/.htaccess.erb')).result(binding)
         io = StringIO.new(accessfile)
-        upload! io, File.join(shared_path, ".htaccess")
+        upload! io, File.join(shared_path, '.htaccess')
       end
       # Set some permissions
       invoke 'wp:set_permissions'
     end
 
-    desc "Setup WP on remote environment"
+    desc 'Setup WP on remote environment'
     task :remote do
       invoke 'db:confirm'
       invoke 'deploy'
       invoke 'wp:setup:generate_remote_files'
       on roles(:web) do
-
         within release_path do
-
           if !fetch(:setup_all)
             # Generate a random password
-            o = [('a'..'z'), ('A'..'Z')].map { |i| i.to_a }.flatten
+            o = [('a'..'z'), ('A'..'Z')].map(&:to_a).flatten
             password = (0...18).map { o[rand(o.length)] }.join
           else
             password = fetch(:wp_pass)
@@ -58,7 +53,7 @@ namespace :wp do
           # Install WordPress
           execute :wp, "core install --url='#{wp_siteurl}' --title='#{title}' --admin_user='#{user}' --admin_password='#{password}' --admin_email='#{email}'"
 
-          if !fetch(:setup_all)
+          unless fetch(:setup_all)
             puts <<-MSG
             \e[32m
             =========================================================================
@@ -72,20 +67,16 @@ namespace :wp do
             \e[0m
             MSG
           end
-
         end
-
       end
     end
 
-    desc "Setup WP on local environment"
+    desc 'Setup WP on local environment'
     task :local do
-
       run_locally do
-
         if !fetch(:setup_all)
           # Generate a random password
-          o = [('a'..'z'), ('A'..'Z')].map { |i| i.to_a }.flatten
+          o = [('a'..'z'), ('A'..'Z')].map(&:to_a).flatten
           password = (0...18).map { o[rand(o.length)] }.join
         else
           password = fetch(:wp_pass)
@@ -98,10 +89,10 @@ namespace :wp do
         wp_siteurl = fetch(:wp_localurl)
 
         # Create wp-config.php
-        database = YAML::load_file('config/database.yml')['local']
-        secret_keys = capture("curl -s -k https://api.wordpress.org/secret-key/1.1/salt")
+        database = YAML.load_file('config/database.yml')['local']
+        secret_keys = capture('curl -s -k https://api.wordpress.org/secret-key/1.1/salt')
         db_config = ERB.new(File.read('config/templates/wp-config.php.erb')).result(binding)
-        File.open("wp-config.php", 'w') {|f| f.write(db_config) }
+        File.open('wp-config.php', 'w') { |f| f.write(db_config) }
 
         # Install WordPress
         execute :wp, "core install --url='#{wp_siteurl}' --title='#{title}' --admin_user='#{user}' --admin_password='#{password}' --admin_email='#{email}'"
@@ -117,27 +108,26 @@ namespace :wp do
         =========================================================================
         \e[0m
         MSG
-
       end
     end
 
-    desc "Setup WP on remote and local environments"
+    desc 'Setup WP on remote and local environments'
     task :both do
       set :setup_all, true
 
       # Generate a random password
-      o = [('a'..'z'), ('A'..'Z')].map { |i| i.to_a }.flatten
+      o = [('a'..'z'), ('A'..'Z')].map(&:to_a).flatten
       password = (0...18).map { o[rand(o.length)] }.join
       set :wp_pass, password
 
       # Setup remote and local envs
-      invoke "wp:setup:remote"
-      invoke "wp:setup:local"
+      invoke 'wp:setup:remote'
+      invoke 'wp:setup:local'
     end
   end
 
   namespace :core do
-    desc "Updates the WP core submodule to the latest tag"
+    desc 'Updates the WP core submodule to the latest tag'
     task :update do
       system('
       cd wordpress
@@ -146,9 +136,7 @@ namespace :wp do
       git checkout $latestTag
       ')
       invoke 'cache:repo:purge'
-      puts "WordPress submodule is now at the latest version. You should now commit your changes."
-
+      puts 'WordPress submodule is now at the latest version. You should now commit your changes.'
     end
   end
-
 end


### PR DESCRIPTION
This is the result of `rubocop -a` which changes the formatting to use normal ruby conventions. The changes are purely syntactic.

I have a number of patches on top of this that changes parts of the code to read more like normal ruby but this would in any case be a good start.
