### PR TITLE
leave the wordpress git repo on https: due to firewall issues

### DIFF
--- a/config/prepare.sh
+++ b/config/prepare.sh
@@ -1,7 +1,7 @@
 rm -rf .git
 git init
 rm -rf wordpress
-git submodule add git://core.git.wordpress.org/ wordpress
+git submodule add https://github.com/WordPress/WordPress.git wordpress
 cd wordpress
 git checkout $(git tag -l --sort -version:refname | head -n 1)
 cd ..


### PR DESCRIPTION
leave the wordpress git repo on https: due to firewall issues with git: protocol