### PR TITLE
Use capistrano ignore for excluding files from deployment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/lib              export-ignore
+/config           export-ignore
+Capfile           export-ignore
+Gemfile           export-ignore
+Gemfile.lock      export-ignore
+readme.md         export-ignore
+.gitattributes    export-ignore
+.gitignore        export-ignore

--- a/.wpignore
+++ b/.wpignore
@@ -1,9 +1,0 @@
-/lib
-/config
-Capfile
-Gemfile
-Gemfile.lock
-readme.md
-.gitattributes
-.gitignore
-.gitmodules


### PR DESCRIPTION
Removed the .wpignore and added the .gitattributes file so files are properly ignored by capistrano during deployment. I did not retain the .gitmodules ignore from the original file as it is needed for submodule deployment.